### PR TITLE
Implemented Deck Deletion

### DIFF
--- a/src/client/scripts/page_loaders/decks_loader.js
+++ b/src/client/scripts/page_loaders/decks_loader.js
@@ -1,7 +1,7 @@
 
 
 
-import { getDeck, addDeck, updateDeck } from "../data_interface/data.js";
+import { getDeck, addDeck, updateDeck, deleteDeck } from "../data_interface/data.js";
 import { generateDeckEntry } from "../generators/entry_generators.js";
 import { generateCard } from "../generators/card_generator.js";
 import { User } from "../structures/user.js";
@@ -204,7 +204,7 @@ export function loadDeckPreview(deck) {
    `
    <div id="deck-creation-page">
    <p>Deck ID: ${deck.id}</p>
-   <input id="add-button" type="button" value="Add">
+   <input id="addDel-button" type="button" value="Add">
    <div id="deck-preview-pane">
     <div id="card-container"> </div>
    </div>
@@ -229,17 +229,24 @@ export function loadDeckPreview(deck) {
 
     populateDeckPreviewPane(deck, 0);
 
-    let addButton = user_decks_container.querySelector("#deck-creation-page").querySelector("#add-button");
+    let addDelButton = user_decks_container.querySelector("#deck-creation-page").querySelector("#addDel-button");
 
-    if (Object.keys(activeUser.metadata).includes(deck.id)) {
-        addButton.value = "Already added";
-        addButton.disabled = true;
+    if (deck.creator.id === User.getActiveUser().id) {
+        addDelButton.value = "Delete";
+        addDelButton.addEventListener("click", async () => {
+            addDelButton.value = "Pending";
+            await activeUser.deleteOwnedDeck(deck);
+            populateDecksContainer(true);
+        });
+    } else if (Object.keys(activeUser.metadata).includes(deck.id)) {
+        addDelButton.value = "Already added";
+        addDelButton.disabled = true; 
     } else {
-        addButton.addEventListener("click", async () => {
-            addButton.value = "Pending";
+        addDelButton.addEventListener("click", async () => {
+            addDelButton.value = "Pending";
             await activeUser.registerDeck(deck);
-            addButton.value = "Added";
-            addButton.disabled = true;
+            addDelButton.value = "Added";
+            addDelButton.disabled = true;
         }) 
     }
 }


### PR DESCRIPTION
Accidentally called it card deletion in the commit, but it's deck deletion. It works as far as I can tell, you just click view on a deck you own and the button that usually says Add or Already Added says Delete, and when you click it it deletes the deck and returns you to the Your Decks screen. In theory there should be an error if you were to log into an account that has added a deck after you delete it, but there's no way to actually do that in the app so it'll never actually occur unless the grader deletes local storage, goes into our code, establishes local storage (or the local database after I make that change) with a different user, loads the program and then acts confused when all of that breaks the app. Would've fixed that, but it would've needed changes to either every creation of a user instance or every creation of a deck instance, which would likely cause an abundance of problems. I'm still thinking of ways to get around that (let me know if you have ideas), but this should be sufficient.